### PR TITLE
Stub font files

### DIFF
--- a/jest-preset.json
+++ b/jest-preset.json
@@ -11,7 +11,7 @@
     ]
   },
   "moduleNameMapper": {
-    "^[./a-zA-Z0-9$_-]+\\.(bmp|gif|jpg|jpeg|png|psd|svg|webp)$": "RelativeImageStub",
+    "^[./a-zA-Z0-9$_-]+\\.(bmp|gif|jpg|jpeg|png|psd|svg|webp|ttf|otf)$": "RelativeImageStub",
     "^React$": "<rootDir>/node_modules/react"
   },
   "modulePathIgnorePatterns": [


### PR DESCRIPTION
Prevent transformation errors in ttf files like:

```
/node_modules/@expo/vector-icons/fonts/Ionicons.ttf:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){
                                                                                             
    SyntaxError: Invalid or unexpected token
```